### PR TITLE
[AppConfig]: fix health-check

### DIFF
--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -21,7 +21,7 @@ USER nginx
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO- http://localhost:8080/health || exit 1
+    CMD wget -qO- http://127.0.0.1:8080/health || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This PR fixes the docker app health check by using IPv4 loopback to avoid localhost resolving to IPv6 (::1) inside the container.

The problem:
- Nginx (otp-app) is listening on port 8080 (IPv4 only: 0.0.0.0:8080)
- The endpoint works on IPv4 loopback:
  - http://127.0.0.1:8080/health -> OK
- The endpoint fails with localhost because localhost resolves to IPv6 first in this container, and nginx is not listening on :::8080

Before:
<img width="365" height="29" alt="image" src="https://github.com/user-attachments/assets/3d3dbb9d-0298-4e73-905d-98d1ee137887" />

After:
<img width="369" height="22" alt="image" src="https://github.com/user-attachments/assets/a4d5d1b0-17a6-410d-8ae7-4c058bdfb2b1" />
