### PR TITLE
[Platform]: Updated GeneCards link to canonical url in Target header

### DIFF
--- a/apps/platform/src/pages/TargetPage/Header.tsx
+++ b/apps/platform/src/pages/TargetPage/Header.tsx
@@ -4,7 +4,7 @@ import { ExternalLink, TepLink, XRefLinks, Header as HeaderBase } from "ui";
 
 function Header({ loading, ensgId, uniprotIds, symbol, name, crisprId }) {
   const ensemblUrl = `https://identifiers.org/ensembl:${ensgId}`;
-  const genecardsUrl = `https://identifiers.org/genecards:${symbol}`;
+  const genecardsUrl = `https://www.genecards.org/card/${symbol}`;
   const hgncUrl = `https://identifiers.org/hgnc.symbol:${symbol}`;
 
   return (


### PR DESCRIPTION
## Description

Updated the GeneCards link in the Target page header to link directly to the canonical url, based on a request from the GeneCards team.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested it in my local and the link works for multiple targets.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
