### PR TITLE
[Platform]: Fix GWAS catalog links where id contains underscore

### DIFF
--- a/apps/platform/src/pages/StudyPage/Header.tsx
+++ b/apps/platform/src/pages/StudyPage/Header.tsx
@@ -40,7 +40,7 @@ function Header({
     }
     sourceLink = {
       id: "GWAS Catalog",
-      url: `https://www.ebi.ac.uk/gwas/studies/${studyId}`,
+      url: `https://www.ebi.ac.uk/gwas/studies/${studyId.replace(/_.*/, "")}`,
     };
   } else if (projectId?.startsWith("FINNGEN")) {
     if (diseases?.length) {


### PR DESCRIPTION
## Description

Fix GWAS catalog links where id contains underscore.

**Issue:** Closes [#4243](https://github.com/opentargets/issues/issues/4243)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
